### PR TITLE
Update AddFe2O3.py

### DIFF
--- a/root/AddFe2O3.py
+++ b/root/AddFe2O3.py
@@ -98,17 +98,17 @@ def AddFe2O3(name):
   f.write("kspace_style    pppm 0.00001					\n")
 
   f.close()
-
+  
 #modifying (rewriting) the file lopls.in.settings
   replaced = False
   for line in fileinput.input(name+".in.settings", inplace=1):
-    if line.startswith('    angle_coeff') and replaced  is False:
-      print("    bond_coeff "+str(nBondTypes+1)+" harmonic 5.63738 1.945000")
-      print("    bond_coeff "+str(nBondTypes+2)+" harmonic 5.63738 2.116000")
-      print("    bond_coeff "+str(nBondTypes+3)+" harmonic 5.63738 2.888000")
-      print("    bond_coeff "+str(nBondTypes+4)+" harmonic 5.63738 2.775000")
-      print("    bond_coeff "+str(nBondTypes+5)+" harmonic 5.63738 2.669000")
-      print("    bond_coeff "+str(nBondTypes+6)+" harmonic 5.63738 2.971000")
+    if line.startswith('angle_coeff') and replaced is False:
+      print("bond_coeff "+str(nBondTypes+1)+" harmonic 5.63738 1.945000")
+      print(" bond_coeff "+str(nBondTypes+2)+" harmonic 5.63738 2.116000")
+      print(" bond_coeff "+str(nBondTypes+3)+" harmonic 5.63738 2.888000")
+      print(" bond_coeff "+str(nBondTypes+4)+" harmonic 5.63738 2.775000")
+      print(" bond_coeff "+str(nBondTypes+5)+" harmonic 5.63738 2.669000")
+      print(" bond_coeff "+str(nBondTypes+6)+" harmonic 5.63738 2.971000")
       replaced = True
     print(line,  end=' ')
 


### PR DESCRIPTION
The indentation before "angle_coeff" is now being recognized by "line.startswith", and resulting in bond coefficients of Fe2O3 being properly written to lopls.in.settings. 

Previously, the bond coefficients:

```
bond_coeff 250 harmonic 5.63738 1.945000
bond_coeff 251 harmonic 5.63738 2.116000
bond_coeff 252 harmonic 5.63738 2.888000
bond_coeff 253 harmonic 5.63738 2.775000
bond_coeff 254 harmonic 5.63738 2.669000
bond_coeff 255 harmonic 5.63738 2.971000
```

were missing and causing the error:

`"ERROR: All bond coeffs are not set"
`
during "write_data" command.

> Python version: Python 3.10.6
> Moltemplate version: v2.20.19 2022-2-06